### PR TITLE
add linked hash map data structure with tests

### DIFF
--- a/wurst/data structures/LinkedHashMap.wurst
+++ b/wurst/data structures/LinkedHashMap.wurst
@@ -152,6 +152,23 @@ class TestClass
     //destroy map2
 
 
+@test function canNestedIterate()
+    let map = new LinkedHashMap<int, int>()
+
+    map..put(1, 2)..put(2, 3)..put(3, 4)..put(4, 5)..put(5, 6)
+
+    var outerSum = 0
+    for kv in map
+        outerSum += kv.key
+
+        var innerSum = 0
+        for innerKv in map
+            innerSum += innerKv.key
+
+        innerSum.assertEquals(15)
+    outerSum.assertEquals(15)
+
+
 @test function canIterateSameMapTwice()
     let map = new LinkedHashMap<int, int>()
 

--- a/wurst/data structures/LinkedHashMap.wurst
+++ b/wurst/data structures/LinkedHashMap.wurst
@@ -194,3 +194,32 @@ class TestClass
     iter2.close()
 
     sum.assertEquals(20)
+
+
+@test function canHandleDestroyedElements()
+    let map = new LinkedHashMap<TestClass, TestClass>()
+
+    let tc1 = new TestClass(1)
+    let tc2 = new TestClass(2)
+    let tc3 = new TestClass(3)
+    let tc4 = new TestClass(4)
+
+    map.put(tc1, tc2)
+    map.put(tc3, tc4)
+
+    var sum = 0
+    for x in map
+        sum += x.key.val
+        sum += x.value.val
+
+    sum.assertEquals(10)
+
+    destroy tc1
+
+    sum = 0
+    for x in map
+        sum += x.key.val
+        sum += x.value.val
+
+    sum.assertEquals(7)
+

--- a/wurst/data structures/LinkedHashMap.wurst
+++ b/wurst/data structures/LinkedHashMap.wurst
@@ -9,6 +9,11 @@ public class LinkedHashMap<K, V>
     private   var      size        = 0
 
 
+    construct()
+        dummy.next = dummy
+        dummy.prev = dummy
+
+
     private function addEntry(LHMEntry<K, V> e)
         if tail == dummy
             dummy.next = e
@@ -335,3 +340,16 @@ class TestClass
     braap.close()
 
     vals.assertEquals(9)
+
+
+@test function iterateEmptyMap()
+    let m = new LinkedHashMap<int, int>()
+
+    for _ in m
+        testFail("Nothing should be iterated here.")
+
+    // Test when there are two LHM's, each with its own dummy.
+    let n = new LinkedHashMap<int, int>()
+
+    for _ in n
+        testFail("Nothing should be iterated here.")

--- a/wurst/data structures/LinkedHashMap.wurst
+++ b/wurst/data structures/LinkedHashMap.wurst
@@ -117,12 +117,12 @@ public class LinkedHashMap<K, V>
 
 public class LHMEntry<K, V>
 
-    constant LinkedHashMap<K, V> parent
+    private constant LinkedHashMap<K, V> parent
     constant K key
     V value
 
-    thistype prev = null
-    thistype next = null
+    protected thistype prev = null
+    protected thistype next = null
 
     construct(LinkedHashMap<K, V> parent, K key, V value)
         this.parent = parent

--- a/wurst/data structures/LinkedHashMap.wurst
+++ b/wurst/data structures/LinkedHashMap.wurst
@@ -1,96 +1,172 @@
 package LinkedHashMap
 import HashMap
-import LinkedList
 import Wurstunit
 
-public class LinkedHashMap<K, V> extends HashMap<K, V>
-    private LinkedList<K>  keys
-    private LHMEntry<K, V> dummy
+public class LinkedHashMap<K, V>
+    protected constant dummy       = new LHMEntry<K, V>(null, null)
+    private   constant keysEntries = new HashMap<K, LHMEntry<K, V>>()
+    private   var      tail        = dummy
+    private   var      size        = 0
 
-    construct()
-        keys  = new LinkedList<K>()
-        dummy = new LHMEntry<K, V>(null, null)
+
+    private function addEntry(LHMEntry<K, V> e)
+        if tail == dummy
+            dummy.next = e
+            tail = e
+            tail.prev = dummy
+            tail.next = dummy
+        else
+            tail.next = e
+            e.prev = tail
+            e.next = dummy
+            tail = e
+
+        size++
+
+
+    /**
+    @returns the last member, removed from the list, on success; or null if
+    empty.
+    */
+    private function popList() returns LHMEntry<K, V>
+        LHMEntry<K, V> ret = null
+        if not tail == dummy
+            ret = tail
+            tail.prev.next = dummy
+
+        return ret
 
 
     /** Saves the given value under the given key. */
-    override function put(K key, V value)
-        if not has(key)
-            keys.add(key)
+    function put(K key, V value)
+        if keysEntries.has(key)
+            let entry = keysEntries.get(key)
+            entry.value = value
+        else
+            let entry = new LHMEntry<K, V>(key, value)
+            addEntry(entry)
+            keysEntries.put(key, entry)
 
-        super.put(key, value)
+
+    function get(K key) returns V
+        return keysEntries.get(key).value
+
+
+    function has(K key) returns bool
+        return keysEntries.has(key)
 
 
     /** Get the number of mappings in this LinkedHashMap. */
     function size() returns int
-        return keys.getSize()
+        return size
 
 
-    /** Removes the value saved under the given key. */
-    override function remove(K key)
-        super.remove(key)
-        keys. remove(key)
+    /**
+    Removes the value saved under the given key.
+
+    @returns true on success, and false if there was no such key.
+    */
+    function remove(K key) returns bool
+        var success = false
+
+        if keysEntries.has(key)
+            success = true
+            let entry = keysEntries.get(key)
+            keysEntries.remove(key)
+            destroy entry
+
+        return success
 
 
-    /** Clears the LinkedHashMap of all entries */
-    override function flush()
-        super.flush()
-        if not keys == null
-            destroy keys
-            keys = new LinkedList<K>()
+    /** Clears the LinkedHashMap of all entries. */
+    function flush()
+        keysEntries.flush()
+        while not tail == dummy
+            let p = popList()
+            if not p == null
+                destroy p
 
 
     /** Gets an iterator for this LinkedHashMap. */
     function iterator() returns LHMIterator<K, V>
-        return new LHMIterator(this, keys)
+        return new LHMIterator(this, dummy)
+
+
+    function removeWhen(LinkedHashMapPredicate<K, V> predicate)
+        let iter = iterator()
+        while iter.hasNext()
+            let kv = iter.next()
+
+            if predicate.isTrueFor(kv)
+                destroy kv
+        destroy predicate
 
 
     ondestroy
-        destroy keys
+        destroy keysEntries
         destroy dummy
 
 
 public class LHMEntry<K, V>
+
     K key
     V value
+
+    thistype prev = null
+    thistype next = null
 
     construct(K key, V value)
         this.key   = key
         this.value = value
 
+    ondestroy
+        this.prev.next = this.next
+        this.next.prev = this.prev
+
 
 public class LHMIterator<K, V>
-    LHMEntry<K, V>      dummy
-    LinkedList<K>       keys
-    LLIterator<K>       keysIterator
-    LinkedHashMap<K, V> parentMap
+    private LHMEntry<K, V>      dummy
+    private LHMEntry<K, V>      current
+    private LinkedHashMap<K, V> parentMap
 
-    construct(LinkedHashMap<K, V> parentMap, LinkedList<K> keys)
-        this.dummy        = new LHMEntry<K, V>(null, null)
-        this.keys         = keys
-        this.keysIterator = keys.iterator()
-        this.parentMap    = parentMap
+    construct(LinkedHashMap<K, V> parentMap, LHMEntry<K, V> dummy)
+        this.dummy     = dummy
+        this.current   = dummy
+        this.parentMap = parentMap
 
 
-    /** Remove the current element from the LinkedHashMap. */
-    function remove()
-        if not dummy.key == null
-            parentMap.remove(dummy.key)
-            keysIterator.remove()
+    /**
+    Remove the current element from the LinkedHashMap.
+    @returns true on success, or false if the map is empty.
+    */
+    function remove() returns bool
+        var ret = false
+        if not current == dummy
+            ret = true
+            parentMap.remove(current.key)
+
+            let toDestroy = current
+            current = current.prev
+            destroy toDestroy
+
+        return ret
 
 
     function hasNext() returns bool
-        return keysIterator.hasNext()
+        return not current.next == dummy
 
 
     function next() returns LHMEntry<K, V>
-        dummy.key   = keysIterator.next()
-        dummy.value = parentMap.get(dummy.key)
-        return dummy
+        current = current.next
+        return current
 
 
     function close()
-        keysIterator.close()
         destroy this
+
+
+public interface LinkedHashMapPredicate<K, V>
+    function isTrueFor(LHMEntry<K, V> kv) returns bool
 
 
 class TestClass
@@ -129,7 +205,6 @@ class TestClass
     let iter = map.iterator()
     while iter.hasNext()
         let entry = iter.next()
-
         sum += entry.key  .val
         sum += entry.value.val
     iter.close()
@@ -214,7 +289,9 @@ class TestClass
 
     sum.assertEquals(10)
 
-    destroy tc1
+    tc1.val = -1
+
+    map.removeWhen((LHMEntry<TestClass, TestClass> kv) -> kv.key.val == -1 or kv.value.val == -1)
 
     sum = 0
     for x in map
@@ -223,3 +300,4 @@ class TestClass
 
     sum.assertEquals(7)
 
+    // destroy map

--- a/wurst/data structures/LinkedHashMap.wurst
+++ b/wurst/data structures/LinkedHashMap.wurst
@@ -117,8 +117,8 @@ public class LinkedHashMap<K, V>
 
 public class LHMEntry<K, V>
 
-    LinkedHashMap<K, V> parent
-    K key
+    constant LinkedHashMap<K, V> parent
+    constant K key
     V value
 
     thistype prev = null

--- a/wurst/data structures/LinkedHashMap.wurst
+++ b/wurst/data structures/LinkedHashMap.wurst
@@ -3,9 +3,9 @@ import HashMap
 import Wurstunit
 
 public class LinkedHashMap<K, V>
-    protected constant dummy       = new LHMEntry<K, V>(null, null)
+    protected constant dummy       = new LHMEntry<K, V>(null, null, null)
     private   constant keysEntries = new HashMap<K, LHMEntry<K, V>>()
-    private   var      tail        = dummy
+    protected var      tail        = dummy
     private   var      size        = 0
 
 
@@ -13,29 +13,17 @@ public class LinkedHashMap<K, V>
         if tail == dummy
             dummy.next = e
             tail = e
-            tail.prev = dummy
-            tail.next = dummy
+            tail.prev  = dummy
+            tail.next  = dummy
         else
             tail.next = e
             e.prev = tail
             e.next = dummy
             tail = e
 
+        dummy.prev = tail
+
         size++
-
-
-    /**
-    @returns the last member, removed from the list, on success; or null if
-    empty.
-    */
-    private function popList() returns LHMEntry<K, V>
-        LHMEntry<K, V> ret = null
-        if not tail == dummy
-            ret  = tail
-            tail = tail.prev
-            tail.next = dummy
-
-        return ret
 
 
     /** Saves the given value under the given key. */
@@ -44,7 +32,7 @@ public class LinkedHashMap<K, V>
             let entry = keysEntries.get(key)
             entry.value = value
         else
-            let entry = new LHMEntry<K, V>(key, value)
+            let entry = new LHMEntry<K, V>(this, key, value)
             addEntry(entry)
             keysEntries.put(key, entry)
 
@@ -72,8 +60,7 @@ public class LinkedHashMap<K, V>
 
         if keysEntries.has(key)
             success = true
-            let entry = keysEntries.get(key)
-            remove(entry)
+            remove(keysEntries.get(key))
 
         return success
 
@@ -81,15 +68,13 @@ public class LinkedHashMap<K, V>
     protected function remove(LHMEntry<K, V> e)
         keysEntries.remove(e.key)
         destroy e
+        size--
 
 
     /** Clears the LinkedHashMap of all entries. */
     function flush()
         keysEntries.flush()
-        while not tail == dummy
-            let p = popList()
-            if not p == null
-                destroy p
+        removeWhen((LHMEntry<K, V> kv) -> true)
 
 
     /** Gets an iterator for this LinkedHashMap. */
@@ -103,8 +88,20 @@ public class LinkedHashMap<K, V>
             let kv = iter.next()
 
             if predicate.isTrueFor(kv)
-                destroy kv
+                iter.remove()
+        iter.close()
         destroy predicate
+
+
+    function forEach(LinkedHashMapCallback<K, V> callback)
+        let iter = iterator()
+        while iter.hasNext()
+            let kv = iter.next()
+
+            callback.run(kv)
+        iter.close()
+
+        destroy callback
 
 
     ondestroy
@@ -115,17 +112,22 @@ public class LinkedHashMap<K, V>
 
 public class LHMEntry<K, V>
 
+    LinkedHashMap<K, V> parent
     K key
     V value
 
     thistype prev = null
     thistype next = null
 
-    construct(K key, V value)
-        this.key   = key
-        this.value = value
+    construct(LinkedHashMap<K, V> parent, K key, V value)
+        this.parent = parent
+        this.key    = key
+        this.value  = value
 
     ondestroy
+        if this.parent.tail == this
+            this.parent.tail = this.parent.tail.prev
+
         this.prev.next = this.next
         this.next.prev = this.prev
 
@@ -141,17 +143,12 @@ public class LHMIterator<K, V>
         this.parentMap = parentMap
 
 
-    /**
-    Remove the current element from the LinkedHashMap.
-    @returns true on success, or false if the map is empty.
-    */
-    function remove() returns bool
-        var ret = false
-        if not current == dummy
-            ret = true
-            parentMap.remove(current)
+    /** Remove the current element from the LinkedHashMap. */
+    function remove()
+        if current == dummy
+            error("Tried to delete dummy from LinkedHashMap iterator.")
 
-        return ret
+        parentMap.remove(current)
 
 
     function hasNext() returns bool
@@ -169,6 +166,10 @@ public class LHMIterator<K, V>
 
 public interface LinkedHashMapPredicate<K, V>
     function isTrueFor(LHMEntry<K, V> kv) returns bool
+
+
+public interface LinkedHashMapCallback<K, V>
+    function run(LHMEntry<K, V> kv)
 
 
 class TestClass
@@ -189,7 +190,7 @@ class TestClass
     let six = map.get(5)
     six.assertEquals(6)
 
-    // destroy map
+    destroy map
 
 
 @test function checkCanIterate()
@@ -212,7 +213,7 @@ class TestClass
     iter.close()
 
     sum.assertEquals(10)
-    // destroy map
+    destroy map
 
 
 @test function canHaveMultipleMaps()
@@ -225,8 +226,8 @@ class TestClass
     map. get(1).assertEquals(2)
     map2.get(3).assertEquals(4)
 
-    //destroy map
-    //destroy map2
+    destroy map
+    destroy map2
 
 
 @test function canNestedIterate()
@@ -302,4 +303,35 @@ class TestClass
 
     sum.assertEquals(7)
 
-    // destroy map
+    destroy map
+
+@test function canBecomeEmptyThenIterateAgainLater()
+    let map = new LinkedHashMap<int, int>()
+
+    map..put(1, 1)..put(2, 2)..put(3, 3)..put(4, 4)
+
+    map.removeWhen((LHMEntry<int, int> kv) -> kv.key < 3)
+
+    map.size().assertEquals(2)
+
+    map.remove(4)
+
+    map.size().assertEquals(1)
+
+    let iter = map.iterator()
+    for kv from iter
+        kv.value.assertEquals(3)
+        iter.remove()
+    iter.close()
+
+    map.size().assertEquals(0)
+
+    map..put(1, 2)..put(2, 3)..put(3, 4)
+
+    var vals = 0
+    let braap = map.iterator()
+    for kv from braap
+        vals += kv.value
+    braap.close()
+
+    vals.assertEquals(9)

--- a/wurst/data structures/LinkedHashMap.wurst
+++ b/wurst/data structures/LinkedHashMap.wurst
@@ -31,8 +31,9 @@ public class LinkedHashMap<K, V>
     private function popList() returns LHMEntry<K, V>
         LHMEntry<K, V> ret = null
         if not tail == dummy
-            ret = tail
-            tail.prev.next = dummy
+            ret  = tail
+            tail = tail.prev
+            tail.next = dummy
 
         return ret
 
@@ -72,10 +73,14 @@ public class LinkedHashMap<K, V>
         if keysEntries.has(key)
             success = true
             let entry = keysEntries.get(key)
-            keysEntries.remove(key)
-            destroy entry
+            remove(entry)
 
         return success
+
+
+    protected function remove(LHMEntry<K, V> e)
+        keysEntries.remove(e.key)
+        destroy e
 
 
     /** Clears the LinkedHashMap of all entries. */
@@ -103,6 +108,7 @@ public class LinkedHashMap<K, V>
 
 
     ondestroy
+        flush()
         destroy keysEntries
         destroy dummy
 
@@ -143,11 +149,7 @@ public class LHMIterator<K, V>
         var ret = false
         if not current == dummy
             ret = true
-            parentMap.remove(current.key)
-
-            let toDestroy = current
-            current = current.prev
-            destroy toDestroy
+            parentMap.remove(current)
 
         return ret
 

--- a/wurst/data structures/LinkedHashMap.wurst
+++ b/wurst/data structures/LinkedHashMap.wurst
@@ -1,0 +1,174 @@
+package LinkedHashMap
+import HashMap
+import LinkedList
+import Wurstunit
+
+public class LinkedHashMap<K, V> extends HashMap<K, V>
+    private LinkedList<K>  keys
+    private LHMEntry<K, V> dummy
+
+    construct()
+        keys      = new LinkedList<K>()
+        dummy     = new LHMEntry<K, V>(null, null)
+
+
+    /** Saves the given value under the given key. */
+    override function put(K key, V value)
+        if not has(key)
+            keys.add(key)
+
+        super.put(key, value)
+
+
+    /** Removes the value saved under the given key. */
+    override function remove(K key)
+        super.remove(key)
+        keys. remove(key)
+
+
+    /** Clears the HashMap of all entries */
+    override function flush()
+        super.flush()
+        if not keys == null
+            destroy keys
+            keys = new LinkedList<K>()
+
+
+    /** Gets an iterator for this LinkedHashMap. */
+    function iterator() returns LHMIterator<K, V>
+        return new LHMIterator(this, keys)
+
+
+    ondestroy
+        destroy keys
+        destroy dummy
+
+
+public class LHMEntry<K, V>
+    K key
+    V value
+
+    construct(K key, V value)
+        this.key   = key
+        this.value = value
+
+
+public class LHMIterator<K, V>
+    LHMEntry<K, V>      dummy
+    LinkedList<K>       keys
+    LLIterator<K>       keysIterator
+    LinkedHashMap<K, V> parentMap
+
+    construct(LinkedHashMap<K, V> parentMap, LinkedList<K> keys)
+        this.dummy        = new LHMEntry<K, V>(null, null)
+        this.keys         = keys
+        this.keysIterator = keys.iterator()
+        this.parentMap    = parentMap
+
+
+    /** Remove the current element from the LinkedHashMap. */
+    function remove()
+        if not dummy.key == null
+            parentMap.remove(dummy.key)
+            keysIterator.remove()
+
+
+    function hasNext() returns bool
+        return keysIterator.hasNext()
+
+
+    function next() returns LHMEntry<K, V>
+        dummy.key   = keysIterator.next()
+        dummy.value = parentMap.get(dummy.key)
+        return dummy
+
+
+    function close()
+        keysIterator.close()
+        destroy this
+
+
+class TestClass
+    int val
+
+    construct(int val)
+        this.val = val
+
+
+    function toString() returns string
+        return "[Test Class] " + val.toString()
+
+
+@test function checkPutFetch()
+    let map = new LinkedHashMap<int, int>()
+    map.put(5, 6)
+
+    let six = map.get(5)
+    six.assertEquals(6)
+
+    destroy map
+
+
+@test function checkCanIterate()
+    let map = new LinkedHashMap<TestClass, TestClass>()
+    let tc1 = new TestClass(1)
+    let tc2 = new TestClass(2)
+    let tc3 = new TestClass(3)
+    let tc4 = new TestClass(4)
+
+    map.put(tc1, tc2)
+    map.put(tc3, tc4)
+
+    var sum = 0
+
+    let iter = map.iterator()
+    while iter.hasNext()
+        let entry = iter.next()
+
+        sum += entry.key  .val
+        sum += entry.value.val
+    iter.close()
+
+    sum.assertEquals(10)
+    // destroy map
+
+
+@test function canHaveMultipleMaps()
+    let map  = new LinkedHashMap<int, int>()
+    let map2 = new LinkedHashMap<int, int>()
+
+    map. put(1, 2)
+    map2.put(3, 4)
+
+    map. get(1).assertEquals(2)
+    map2.get(3).assertEquals(4)
+
+    //destroy map
+    //destroy map2
+
+
+@test function canIterateSameMapTwice()
+    let map = new LinkedHashMap<int, int>()
+
+    map.put(1, 2)
+    map.put(3, 4)
+
+    var sum = 0
+
+    let iter = map.iterator()
+    while iter.hasNext()
+        let entry = iter.next()
+
+        sum += entry.key
+        sum += entry.value
+    iter.close()
+
+    let iter2 = map.iterator()
+    while iter2.hasNext()
+        let entry = iter2.next()
+
+        sum += entry.key
+        sum += entry.value
+    iter2.close()
+
+    sum.assertEquals(20)

--- a/wurst/data structures/LinkedHashMap.wurst
+++ b/wurst/data structures/LinkedHashMap.wurst
@@ -8,8 +8,8 @@ public class LinkedHashMap<K, V> extends HashMap<K, V>
     private LHMEntry<K, V> dummy
 
     construct()
-        keys      = new LinkedList<K>()
-        dummy     = new LHMEntry<K, V>(null, null)
+        keys  = new LinkedList<K>()
+        dummy = new LHMEntry<K, V>(null, null)
 
 
     /** Saves the given value under the given key. */
@@ -20,13 +20,18 @@ public class LinkedHashMap<K, V> extends HashMap<K, V>
         super.put(key, value)
 
 
+    /** Get the number of mappings in this LinkedHashMap. */
+    function size() returns int
+        return keys.getSize()
+
+
     /** Removes the value saved under the given key. */
     override function remove(K key)
         super.remove(key)
         keys. remove(key)
 
 
-    /** Clears the HashMap of all entries */
+    /** Clears the LinkedHashMap of all entries */
     override function flush()
         super.flush()
         if not keys == null
@@ -106,7 +111,7 @@ class TestClass
     let six = map.get(5)
     six.assertEquals(6)
 
-    destroy map
+    // destroy map
 
 
 @test function checkCanIterate()


### PR DESCRIPTION
I also have a wicked FV test that passes without issue:

```
        // LinkedHashMap test!
        doAfter(1., () -> begin
            let m = new LinkedHashMap<int, int>()

            m.size().assertEquals(0)

            m.put(1, 2)
            m.put(2, 3)
            m.put(3, 4)
            m.put(4, 5)
            m.put(5, 6)

            m.size().assertEquals(5)

            let iter = m.iterator()
            var sum = 0
            while iter.hasNext()
                let kv = iter.next()

                sum += kv.value
            iter.close()

            sum.assertEquals(20)
            m.size().assertEquals(5)

            let iter2 = m.iterator()
            while iter2.hasNext()
                let kv = iter2.next()

                if kv.key % 2 == 0
                    iter2.remove()
            iter2.close()

            m.size().assertEquals(3)

            let iter3 = m.iterator()
            sum = 0
            while iter3.hasNext()
                let kv = iter3.next()

                sum += kv.value
            iter3.close()

            sum.assertEquals(12)

            // Lots of hashmaps
            doPeriodicallyCounted(1. / 10000., 10000, (CallbackCounted _) -> begin
                let g = new LinkedHashMap<int, int>()

                g..put(3, 4)..put(4, 5)..put(5, 6)..put(6, 7)

                var s = 0
                let i = g.iterator()
                while i.hasNext()
                    let kv = i.next()

                    s += (kv.key + kv.value)
                i.close()

                s.assertEquals(40)

                destroy g
            end)

            print("done.")
        end)
```
