### PR TITLE
[knockback3] fix map usage for setVel method

### DIFF
--- a/wurst/systems/Knockback3.wurst
+++ b/wurst/systems/Knockback3.wurst
@@ -95,6 +95,7 @@ public class Knockback3
             knockback.del += v
         else
             knockback     = new Knockback3()
+            unitNodes.put(u, knockback)
             knockback.u   = u
             knockback.del = v
             if size == 1


### PR DESCRIPTION
Without this fix, `setVel` behaves essentially the same as `add`, which is incorrect.
