### PR TITLE
replace spelling of beserk to berserk

### DIFF
--- a/wurst/objediting/AbilityObjEditing.wurst
+++ b/wurst/objediting/AbilityObjEditing.wurst
@@ -4724,7 +4724,7 @@ public class AbilityDefinitionIntelligenceBonusPlus6 extends AbilityDefinition
 
 
 
-public class AbilityDefinitionBeserk extends AbilityDefinition
+public class AbilityDefinitionBerserk extends AbilityDefinition
 	construct(int newAbilityId)
 		super(newAbilityId, 'Absk')
 

--- a/wurst/small helpers/Assets.wurst
+++ b/wurst/small helpers/Assets.wurst
@@ -3235,7 +3235,7 @@ public class Other
 	static constant treeoflife_portrait = "buildings\\nightelf\\treeoflife\\treeoflife_portrait.mdx"
 	static constant treeoflifeupgradetargetart = "abilities\\spells\\nightelf\\treeoflifeupgrade\\treeoflifeupgradetargetart.mdx"
 	static constant treeoflifeupgradetargetarthand = "abilities\\spells\\nightelf\\treeoflifeupgrade\\treeoflifeupgradetargetarthand.mdx"
-	static constant trollbeserkertarget = "abilities\\spells\\orc\\trollberserk\\trollbeserkertarget.mdx"
+	static constant trollberserkertarget = "abilities\\spells\\orc\\trollberserk\\trollbeserkertarget.mdx"
 	static constant trough0 = "doodads\\lordaeronsummer\\props\\trough\\trough0.mdx"
 	static constant trough1 = "doodads\\lordaeronsummer\\props\\trough\\trough1.mdx"
 	static constant trueshotaura = "abilities\\spells\\nightelf\\trueshotaura\\trueshotaura.mdx"


### PR DESCRIPTION
Blizzard uses this misspelling in a couple of places, but we have no reason to
not use the correct spelling.

Addresses #10.