### PR TITLE
increase visibility of disable and enable functions for damage detection. necessary for fetching armor type

### DIFF
--- a/wurst/systems/DamageDetection.wurst
+++ b/wurst/systems/DamageDetection.wurst
@@ -21,11 +21,11 @@ public function addOnDamageFunc(boolexpr cf)
 	funcNext++
 
 /** Disables the damage events */
-function disableDamageDetect()
+public function disableDamageDetect()
 	DisableTrigger(current)
 
 /** Enables the damage events */
-function enableDamageDetect()
+public function enableDamageDetect()
 	EnableTrigger(current)
 
 


### PR DESCRIPTION
Current master branch has some dead functions for enable/disable of damage detection.

In fact, these functions are useful.